### PR TITLE
Keep track of which pushbuffers modify which bos and wait for them to finish when the bo is mapped.

### DIFF
--- a/include/nouveau.h
+++ b/include/nouveau.h
@@ -148,6 +148,7 @@ int nouveau_bo_wait(struct nouveau_bo *, uint32_t access,
 int nouveau_bo_prime_handle_ref(struct nouveau_device *, int prime_fd,
 				struct nouveau_bo **);
 int nouveau_bo_set_prime(struct nouveau_bo *, int *prime_fd);
+int nouveau_bo_get_syncpoint(struct nouveau_bo *, unsigned int *);
 
 struct nouveau_list {
 	struct nouveau_list *prev;

--- a/include/nouveau_drm.h
+++ b/include/nouveau_drm.h
@@ -143,7 +143,7 @@ struct drm_nouveau_gem_pushbuf_bo_presumed {
 };
 
 struct drm_nouveau_gem_pushbuf_bo {
-	__u64 user_priv;
+	struct nouveau_bo *bo; // The backing bo where this buffer is stored.
 	__u32 handle;
 	__u32 read_domains;
 	__u32 write_domains;

--- a/include/nouveau_drm.h
+++ b/include/nouveau_drm.h
@@ -151,20 +151,6 @@ struct drm_nouveau_gem_pushbuf_bo {
 	struct drm_nouveau_gem_pushbuf_bo_presumed presumed;
 };
 
-#define NOUVEAU_GEM_RELOC_LOW  (1 << 0)
-#define NOUVEAU_GEM_RELOC_HIGH (1 << 1)
-#define NOUVEAU_GEM_RELOC_OR   (1 << 2)
-#define NOUVEAU_GEM_MAX_RELOCS 1024
-struct drm_nouveau_gem_pushbuf_reloc {
-	__u32 reloc_bo_index;
-	__u32 reloc_bo_offset;
-	__u32 bo_index;
-	__u32 flags;
-	__u32 data;
-	__u32 vor;
-	__u32 tor;
-};
-
 #define NOUVEAU_GEM_MAX_PUSH 512
 struct drm_nouveau_gem_pushbuf_push {
 	__u32 bo_index;

--- a/include/nouveau_drm.h
+++ b/include/nouveau_drm.h
@@ -147,7 +147,6 @@ struct drm_nouveau_gem_pushbuf_bo {
 	__u32 handle;
 	__u32 read_domains;
 	__u32 write_domains;
-	__u32 valid_domains;
 	struct drm_nouveau_gem_pushbuf_bo_presumed presumed;
 };
 

--- a/source/nouveau.c
+++ b/source/nouveau.c
@@ -165,7 +165,6 @@ nouveau_device_new(struct nouveau_object *parent, int32_t oclass,
 {
 	struct nouveau_drm *drm = nouveau_drm(parent);
 	struct nouveau_device_priv *nvdev;
-	char *tmp;
 	Result rc;
 	CALLED();
 
@@ -184,21 +183,6 @@ nouveau_device_new(struct nouveau_object *parent, int32_t oclass,
 		TRACE("Failed to create GPU.");
 		return -rc;
 	}
-
-	if (!R_SUCCEEDED(svcGetInfo(&nvdev->base.gart_size, 6, CUR_PROCESS_HANDLE, 0)))
-	{
-		TRACE("Failed to get physical memory size.");
-		return -errno;
-	}
-
-	tmp = getenv("NOUVEAU_LIBDRM_VRAM_LIMIT_PERCENT");
-	if (tmp)
-		nvdev->vram_limit_percent = atoi(tmp);
-	else
-		nvdev->vram_limit_percent = 80;
-
-	nvdev->base.gart_limit =
-		(nvdev->base.gart_size * nvdev->vram_limit_percent) / 100;
 
 	mutexInit(&nvdev->lock);
 	DRMINITLISTHEAD(&nvdev->bo_list);

--- a/source/nouveau.c
+++ b/source/nouveau.c
@@ -351,9 +351,10 @@ nouveau_bo_new(struct nouveau_device *dev, uint32_t flags, uint32_t align,
 	bo->size = nvbo->buffer.size;
 	bo->flags = flags;
 	bo->offset = kind != NvKind_Pitch ? nvBufferGetGpuAddrTexture(&nvbo->buffer) : nvBufferGetGpuAddr(&nvbo->buffer);
-	bo->map = nvBufferGetCpuAddr(&nvbo->buffer);
+	bo->map = NULL;
 	nvbo->map_handle = nvBufferGetGpuAddr(&nvbo->buffer);
-	memset(bo->map, 0, bo->size);
+	nvbo->map_addr = nvBufferGetCpuAddr(&nvbo->buffer);
+	memset(nvbo->map_addr, 0, bo->size);
 
 	if (config)
 		bo->config = *config;
@@ -467,19 +468,8 @@ nouveau_bo_map(struct nouveau_bo *bo, uint32_t access,
 	       struct nouveau_client *client)
 {
 	CALLED();
-#if 0
 	struct nouveau_bo_priv *nvbo = nouveau_bo(bo);
-	Result rc;
-	if (!nvbo->map_handle)
-	{
-		rc = nvBufferMapAsTexture(&nvbo->buffer, bo->config.nvc0.memtype);
-		if (R_FAILED(rc))
-			return -rc;
-		nvbo->map_handle = nvBufferGetGpuAddrTexture(&nvbo->buffer);
-	}
-
-	bo->map = (void*)nvbo->map_handle;
-#endif
+	bo->map = (void*)nvbo->map_addr;
 	return nouveau_bo_wait(bo, access, client);
 }
 
@@ -487,5 +477,5 @@ void
 nouveau_bo_unmap(struct nouveau_bo *bo)
 {
 	CALLED();
-	//bo->map = NULL;
+	bo->map = NULL;
 }

--- a/source/nouveau.c
+++ b/source/nouveau.c
@@ -336,7 +336,6 @@ nouveau_bo_new(struct nouveau_device *dev, uint32_t flags, uint32_t align,
 	bo->flags = flags;
 	bo->offset = kind != NvKind_Pitch ? nvBufferGetGpuAddrTexture(&nvbo->buffer) : nvBufferGetGpuAddr(&nvbo->buffer);
 	bo->map = NULL;
-	nvbo->map_handle = nvBufferGetGpuAddr(&nvbo->buffer);
 	nvbo->map_addr = nvBufferGetCpuAddr(&nvbo->buffer);
 	memset(nvbo->map_addr, 0, bo->size);
 
@@ -469,7 +468,7 @@ nouveau_bo_map(struct nouveau_bo *bo, uint32_t access,
 {
 	CALLED();
 	struct nouveau_bo_priv *nvbo = nouveau_bo(bo);
-	bo->map = (void*)nvbo->map_addr;
+	bo->map = nvbo->map_addr;
 	return nouveau_bo_wait(bo, access, client);
 }
 

--- a/source/nouveau.c
+++ b/source/nouveau.c
@@ -458,9 +458,25 @@ int
 nouveau_bo_wait(struct nouveau_bo *bo, uint32_t access,
 		struct nouveau_client *client)
 {
-	// TODO: Unimplemented
 	CALLED();
-	return 0;
+	struct nouveau_bo_priv *nvbo = nouveau_bo(bo);
+	struct nouveau_pushbuf *push;
+	int ret = 0;
+
+	if (!(access & NOUVEAU_BO_RDWR))
+		return 0;
+
+	push = cli_push_get(client, bo);
+	if (push && push->channel)
+		nouveau_pushbuf_kick(push, push->channel);
+
+	if (!nvbo->head.next && !(nvbo->access & NOUVEAU_BO_WR) &&
+				!(access & NOUVEAU_BO_WR))
+		return 0;
+
+	// TODO: Wait for the pushbuf to finish executing
+	nvbo->access = 0;
+	return ret;
 }
 
 int

--- a/source/nouveau.c
+++ b/source/nouveau.c
@@ -440,6 +440,18 @@ nouveau_bo_set_prime(struct nouveau_bo *bo, int *prime_fd)
 }
 
 int
+nouveau_bo_get_syncpoint(struct nouveau_bo *bo, unsigned int *out_threshold)
+{
+	CALLED();
+	struct nouveau_bo_priv *nvbo = nouveau_bo(bo);
+
+	if (out_threshold)
+		*out_threshold = nvbo->fence.value;
+
+	return nvbo->fence.id;
+}
+
+int
 nouveau_bo_wait(struct nouveau_bo *bo, uint32_t access,
 		struct nouveau_client *client)
 {

--- a/source/nouveau.c
+++ b/source/nouveau.c
@@ -185,7 +185,7 @@ nouveau_device_new(struct nouveau_object *parent, int32_t oclass,
 		return -rc;
 	}
 
-	if (!R_SUCCEEDED(svcGetInfo(&nvdev->base.vram_size, 6, CUR_PROCESS_HANDLE, 0)))
+	if (!R_SUCCEEDED(svcGetInfo(&nvdev->base.gart_size, 6, CUR_PROCESS_HANDLE, 0)))
 	{
 		TRACE("Failed to get physical memory size.");
 		return -errno;
@@ -197,8 +197,8 @@ nouveau_device_new(struct nouveau_object *parent, int32_t oclass,
 	else
 		nvdev->vram_limit_percent = 80;
 
-	nvdev->base.vram_limit =
-		(nvdev->base.vram_size * nvdev->vram_limit_percent) / 100;
+	nvdev->base.gart_limit =
+		(nvdev->base.gart_size * nvdev->vram_limit_percent) / 100;
 
 	mutexInit(&nvdev->lock);
 	DRMINITLISTHEAD(&nvdev->bo_list);

--- a/source/private.h
+++ b/source/private.h
@@ -69,6 +69,7 @@ struct nouveau_bo_priv {
 	struct nouveau_list head;
 	atomic_t refcnt;
 	uint64_t map_handle;
+	void* map_addr;
 	uint32_t name;
 	uint32_t access;
 	NvBuffer buffer;

--- a/source/private.h
+++ b/source/private.h
@@ -68,7 +68,6 @@ struct nouveau_bo_priv {
 	struct nouveau_bo base;
 	struct nouveau_list head;
 	atomic_t refcnt;
-	uint64_t map_handle;
 	void* map_addr;
 	uint32_t name;
 	uint32_t access;

--- a/source/private.h
+++ b/source/private.h
@@ -72,6 +72,7 @@ struct nouveau_bo_priv {
 	uint32_t name;
 	uint32_t access;
 	NvBuffer buffer;
+	NvFence fence;
 };
 
 static inline struct nouveau_bo_priv *

--- a/source/pushbuf.c
+++ b/source/pushbuf.c
@@ -88,7 +88,17 @@ pushbuf_kref_fits(struct nouveau_pushbuf *push, struct nouveau_bo *bo,
 {
 	CALLED();
 
-	// Unimplemented
+	struct nouveau_pushbuf_priv *nvpb = nouveau_pushbuf(push);
+	struct nouveau_pushbuf_krec *krec = nvpb->krec;
+	struct nouveau_device *dev = push->client->device;
+
+	// Check if the buffer fits in the available GART.
+	if (krec->gart_used + bo->size > dev->gart_limit) {
+		TRACE("buffer with size %u does not fit in memory. used=%u limit %u\n", 
+			bo->size, krec->gart_used, dev->gart_limit);
+		return false;
+	}
+	krec->gart_used += bo->size;
 	return true;
 }
 

--- a/source/pushbuf.c
+++ b/source/pushbuf.c
@@ -53,8 +53,6 @@ struct nouveau_pushbuf_krec {
 	int nr_buffer;
 	int nr_reloc;
 	int nr_push;
-	uint64_t vram_used;
-	uint64_t gart_used;
 };
 
 struct nouveau_pushbuf_priv {
@@ -86,17 +84,7 @@ pushbuf_kref_fits(struct nouveau_pushbuf *push, struct nouveau_bo *bo,
 {
 	CALLED();
 
-	struct nouveau_pushbuf_priv *nvpb = nouveau_pushbuf(push);
-	struct nouveau_pushbuf_krec *krec = nvpb->krec;
-	struct nouveau_device *dev = push->client->device;
-
-	// Check if the buffer fits in the available GART.
-	if (krec->gart_used + bo->size > dev->gart_limit) {
-		TRACE("buffer with size %u does not fit in memory. used=%u limit %u\n", 
-			bo->size, krec->gart_used, dev->gart_limit);
-		return false;
-	}
-	krec->gart_used += bo->size;
+	// Note: We assume we always have enough memory for the bo.
 	return true;
 }
 
@@ -314,8 +302,6 @@ pushbuf_flush(struct nouveau_pushbuf *push)
 	}
 
 	krec = nvpb->krec;
-	krec->vram_used = 0;
-	krec->gart_used = 0;
 	krec->nr_buffer = 0;
 	krec->nr_reloc = 0;
 	krec->nr_push = 0;

--- a/source/pushbuf.c
+++ b/source/pushbuf.c
@@ -113,12 +113,6 @@ pushbuf_kref(struct nouveau_pushbuf *push, struct nouveau_bo *bo,
 
 	kref = cli_kref_get(push->client, bo);
 	if (kref) {
-		/* possible conflict in memory types - flush and retry */
-		if (!(kref->valid_domains & domains)) {
-			return NULL;
-		}
-
-		kref->valid_domains &= domains;
 		kref->write_domains |= domains_wr;
 		kref->read_domains  |= domains_rd;
 	} else {
@@ -129,7 +123,6 @@ pushbuf_kref(struct nouveau_pushbuf *push, struct nouveau_bo *bo,
 		kref = &krec->buffer[krec->nr_buffer++];
 		kref->bo = bo;
 		kref->handle = bo->handle;
-		kref->valid_domains = domains;
 		kref->write_domains = domains_wr;
 		kref->read_domains = domains_rd;
 		kref->presumed.valid = 1;
@@ -167,9 +160,8 @@ pushbuf_dump(struct nouveau_pushbuf_krec *krec, int krec_id, int chid)
 
 	kref = krec->buffer;
 	for (i = 0; i < krec->nr_buffer; i++, kref++) {
-		TRACE("ch%d: buf %08x %08x %08x %08x %08x\n", chid, i,
-		    kref->handle, kref->valid_domains,
-		    kref->read_domains, kref->write_domains);
+		TRACE("ch%d: buf %08x %08x %08x %08x\n", chid, i,
+		    kref->handle, kref->read_domains, kref->write_domains);
 	}
 
 	kpsh = krec->push;


### PR DESCRIPTION
Fixes operations like glReadPixels not blocking until the buffer is ready before returning.

Most of this code was ported from the original libdrm nouveau code with some modifications to remove stuff not relevant to our use case.
The behavior was verified using piglit tests running on the yuzu emulator. When fencing is implemented then we'll be able to test this in real hardware.

I tried my best to separate the change into several small commits, you should be able to review this on a commit-by-commit basis.